### PR TITLE
Implement discover all the instances and also by service name

### DIFF
--- a/src/main/java/eu/fair4health/discovery/controller/DiscoveryController.java
+++ b/src/main/java/eu/fair4health/discovery/controller/DiscoveryController.java
@@ -35,13 +35,16 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
+
+import org.springframework.http.HttpHeaders;
 
 import com.ecwid.consul.v1.agent.model.NewService;
 
 import eu.fair4health.discovery.service.Service;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 @RestController
 @EnableAutoConfiguration
@@ -54,23 +57,28 @@ public class DiscoveryController {
 
     @ApiOperation(value = "Register an agent in the system")
     @PostMapping("/register")
-    public void register(@RequestBody NewService service) {
-        log.info("Register instance for {}", service);
-        discoveryService.register(service);
+    public void register(@ApiParam(value = "Bearer <token>") 
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String token, 
+        @RequestBody NewService service) {
+            log.info("Register instance for {}", service);
+            discoveryService.register(service);
     }
 
     @ApiOperation(value = "Discover agents in the system by name")
     @GetMapping("/discover/{name}")
-    public List<ServiceInstance> discover(@PathVariable("name") String name) {
-        log.info("Discover instances for service {}", name);
-        return discoveryService.discover(name);
+    public List<ServiceInstance> discover(@ApiParam(value = "Bearer <token>") 
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String token, 
+        @PathVariable("name") String name) {
+            log.info("Discover instances for service {}", name);
+            return discoveryService.discover(name);
     }
 
 
     @ApiOperation(value = "Discover all the agents in the system")
     @GetMapping("/discover")
-    public List<ServiceInstance> discoverAll() {
-        log.info("Discover all the instances");
-        return discoveryService.discoverAll();
+    public List<ServiceInstance> discoverAll(@ApiParam(value = "Bearer <token>") 
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+            log.info("Discover all the instances");
+            return discoveryService.discoverAll();
     }
 }

--- a/src/main/java/eu/fair4health/discovery/controller/DiscoveryController.java
+++ b/src/main/java/eu/fair4health/discovery/controller/DiscoveryController.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -54,14 +55,22 @@ public class DiscoveryController {
     @ApiOperation(value = "Register an agent in the system")
     @PostMapping("/register")
     public void register(@RequestBody NewService service) {
-        log.info("Register operation with {}", service);
+        log.info("Register instance for {}", service);
         discoveryService.register(service);
     }
 
     @ApiOperation(value = "Discover agents in the system by name")
-    @GetMapping("/discover")
-    public List<ServiceInstance> discover(@RequestParam String name) {
-        log.info("Discover operation with {}", name);
+    @GetMapping("/discover/{name}")
+    public List<ServiceInstance> discover(@PathVariable("name") String name) {
+        log.info("Discover instances for service {}", name);
         return discoveryService.discover(name);
+    }
+
+
+    @ApiOperation(value = "Discover all the agents in the system")
+    @GetMapping("/discover")
+    public List<ServiceInstance> discoverAll() {
+        log.info("Discover all the instances");
+        return discoveryService.discoverAll();
     }
 }

--- a/src/main/java/eu/fair4health/discovery/service/DiscoveryService.java
+++ b/src/main/java/eu/fair4health/discovery/service/DiscoveryService.java
@@ -27,7 +27,9 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
@@ -41,14 +43,37 @@ public class DiscoveryService implements Service {
     // Constants
     RestTemplate restTemplate = new RestTemplate();
 
+    // Inject the Discovery Client
+    @Autowired
+    private DiscoveryClient discoveryClient;
+
     @Override
     public void register(NewService service) {
         return;
     }
-    
+
     @Override
     public List<ServiceInstance> discover(String name) {
-        return new ArrayList<ServiceInstance>();
+        if (name.trim().isEmpty() == true)
+            return new ArrayList<ServiceInstance>();
+
+        List<ServiceInstance> instances = discoveryClient.getInstances(name);
+        return instances;
+    }
+
+    @Override
+    public List<ServiceInstance> discoverAll() {
+
+        List<ServiceInstance> instances = new ArrayList<ServiceInstance>();
+
+        List<String> services = discoveryClient.getServices();
+        for (String s : services) {
+            List<ServiceInstance> instancesByService = discoveryClient.getInstances(s);
+            for (ServiceInstance SI : instancesByService)
+                instances.add(SI);
+        }
+        
+        return instances;
     }
 
     public void setRestTemplate(RestTemplate restTemplate) {

--- a/src/main/java/eu/fair4health/discovery/service/Service.java
+++ b/src/main/java/eu/fair4health/discovery/service/Service.java
@@ -34,5 +34,6 @@ import com.ecwid.consul.v1.agent.model.NewService;
 public interface Service {
 	public void register(NewService service);
         public List<ServiceInstance> discover(String name);
+        public List<ServiceInstance> discoverAll();
 }
 

--- a/src/test/java/eu/fair4health/discovery/DiscoveryControllerTest.java
+++ b/src/test/java/eu/fair4health/discovery/DiscoveryControllerTest.java
@@ -59,6 +59,8 @@ public class DiscoveryControllerTest {
     @Mock
     private DiscoveryService discoveryService;
 
+    private String authToken = "123456789";
+    
     /**
      * Init the Mockito annotations and MVC mock.
      * 
@@ -81,6 +83,8 @@ public class DiscoveryControllerTest {
         List<ServiceInstance> result = new ArrayList<ServiceInstance>();
         Mockito.when(discoveryService.discover("test"))
             .thenReturn(result);
+        Mockito.when(discoveryService.discoverAll())
+            .thenReturn(result);
     }
 
     /**
@@ -89,10 +93,24 @@ public class DiscoveryControllerTest {
      * @return void
      */
     @Test
-    public void discoverServiceByName_returnOk() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/discover?name=test"))
+    public void discoverInstancesByName_returnOk() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/discover?name=test")
+            .header("Authorization", "Bearer " + authToken))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
-        // .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        // .andExpect(content().contentType("3"));
+    }
+    
+
+    /**
+     * Test the discover all instances controller mocking the service.
+     * 
+     * @return void
+     */
+    @Test
+    public void discoverAllInstances_returnOk() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/discover")
+            .header("Authorization", "Bearer " + authToken))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
     }
 }

--- a/src/test/java/eu/fair4health/discovery/DiscoveryServiceTest.java
+++ b/src/test/java/eu/fair4health/discovery/DiscoveryServiceTest.java
@@ -28,11 +28,13 @@ import static org.junit.Assert.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.hamcrest.Matchers;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -46,18 +48,18 @@ public class DiscoveryServiceTest {
      * 
      * @return the Calculator Service
      */
-    @TestConfiguration
+    /* @TestConfiguration
     static class DiscoveryServiceImplTestContextConfiguration {
 
         @Bean
-        public DiscoveryService authService() {
+        public DiscoveryService discoveryService() {
             return new DiscoveryService();
         }
-    }
+    } */
 
-    @Autowired
+    @InjectMocks
     private DiscoveryService discoveryService;
-
+    
     /**
      * SetUp the system to mock the services.
      * 


### PR DESCRIPTION
## Proposed Changes

  - Implement controller and service for discover all the instances endpoint
  - Implement discover by service name endpoint
  - Trim the param name to avoid errors discovering instances by service name

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [ ] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Fixes #2 

## What is the new behavior?

- Find all the agents registered 
- Find instances registered by service name

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
