### PR TITLE
We only want to discover the agents (not cosul servie)

### DIFF
--- a/src/main/java/eu/fair4health/discovery/service/DiscoveryService.java
+++ b/src/main/java/eu/fair4health/discovery/service/DiscoveryService.java
@@ -146,7 +146,9 @@ public class DiscoveryService implements Service {
         for (String s : services) {
             List<ServiceInstance> instancesByService = discoveryClient.getInstances(s);
             for (ServiceInstance SI : instancesByService)
-                instances.add(SI);
+            	//not add consul service created by default by consult
+            	if (!SI.getServiceId().equals("consul"))
+                	instances.add(SI);
         }
         
         return instances;


### PR DESCRIPTION
## Proposed Changes

  - On discover ALLregistered agents, returns “only” the Agents, not the consul service itself 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x ] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying -->
Issue Number: #9 

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #9 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- "consul" service cretated automatiically  by consul is not provided

## Does this introduce a breaking change?

- [ ] Yes
- [x ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
